### PR TITLE
Introducing MultiLineRun.py, enabling pasting several lines of code

### DIFF
--- a/idlesporklib/MultiLineRun.py
+++ b/idlesporklib/MultiLineRun.py
@@ -14,13 +14,6 @@
 
 from __future__ import print_function
 
-config_extension_def = """
-[MultiLineRun]
-enable=1
-enable_editor=0
-enable_shell=1
-"""
-
 from idlesporklib.configHandler import idleConf
 from idlesporklib.Delegator import Delegator
 import time

--- a/idlesporklib/MultiLineRun.py
+++ b/idlesporklib/MultiLineRun.py
@@ -7,8 +7,6 @@
 ##    License: See LICENSE.txt
 ##    """
 
-
-
 ##
 ##  This extension allows for pasting of multiple lines of code into the shell
 ##  for execution. This addresses http://bugs.python.org/issue3559
@@ -29,6 +27,8 @@ import time
 import re
 import sys
 import traceback
+
+INDENT_CHARS = set(" \t")
 
 class MultiLineDelegator(Delegator):
     def __init__(self, callback):
@@ -54,8 +54,7 @@ class MultiLineDelegator(Delegator):
         self.delegate.delete(index1, index2)
 
 
-class MultiLineRun:
-
+class MultiLineRun(object):
     # eol code from IOBinding.py
     eol = r"(\r\n)|\n|\r"  # \r\n (Windows), \n (UNIX), or \r (Mac)
     eol_re = re.compile(eol)
@@ -73,8 +72,6 @@ class MultiLineRun:
         if wsys == 'x11':
             self.text.bind('<Button-2>', self.paste, '+')  # For X11 middle click
 
-        self.playback_list = []
-
     def paste(self, event=None):
         self.mld.paste = True
 
@@ -88,85 +85,38 @@ class MultiLineRun:
     def play(self, chars):
         chars = self.eol_re.sub(r"\n", chars)
 
-        L = [] # list of entries to play into the shell
-        index = 0
-        while True:
-            next_index = chars.find('\n', index)
-            if next_index > -1:
-                line = chars[index:next_index]
-                L.append((line, True))
-            else:
-                line = chars[index:]
-                L.append((line, False))
-                break
-            index = next_index + 1
+        lines = chars.splitlines()
+        lines = self.dedent(lines)
 
-        L = self.dedent(L)
-        self.playback_list = L
-        self._pre_playback()
-        self.do_playback()
+        self.text.insert("insert", "\n".join(lines))
 
-    def dedent(self, L):
+    def dedent(self, lines):
         """
         remove maximal amount of indents/spaces shared by all lines
         to enable pasting an equally indented region
-        Also remove empty lines, because they cause execution half-way
         """
         # exclude commented-out lines, empty lines for calculation of greatest common indent to strip
-        Lcode = [line for line,ret in L if line.rstrip() and not line.startswith('#')]
 
-        # calculate min number of tabs
-        dedent_tab =0
-        while all(map(lambda line: line.startswith('\t'),Lcode)):
-            Lcode = [x[1:] for x in Lcode]
-            dedent_tab += 1
+        indentation = self.find_max_indent(lines)
+        indentation_len = len(indentation)
+        lines = [line[indentation_len:] if line.startswith(indentation) else line
+                 for line in lines]
+        return lines
 
-        if not dedent_tab:
-            dedent_space = 0
-            while all(map(lambda line: line.startswith(' '), Lcode)):
-                Lcode = [x[1:] for x in Lcode]
-                dedent_space += 1
-            depth = dedent_space
-            src = '\n'.join([line for line,ret in L if line.rstrip()])
-            src = re.sub(r"(?<![^\n]) {%i,%i}" % (depth, depth), "", src)
-            L = zip(src.split('\n'),[ret for line,ret in L if line.rstrip()])
-        else:
-            depth = dedent_tab
-            src = '\n'.join([line for line,ret in L if line.rstrip()])
-            src = re.sub(r"(?<![^\n])\t{%i,%i}" % (depth, depth), "", src)
-            L = zip(src.split('\n'),[ret for line,ret in L if line.rstrip()])
-
-        return L
-
-    def _pre_playback(self):
-        # newline_and_indent can be problematic - replace it momentarily
-        self.n = self.editwin.newline_and_indent_event
-        def simple_return(text = self.text):
-            text.insert('insert', '\n')
-        self.editwin.newline_and_indent_event = lambda *args, **kwargs: simple_return()
-
-    def _post_playback(self):
-        self.editwin.newline_and_indent_event = self.n
-
-    def do_playback(self):
-        self.mld.paste = False
-        e = self.editwin
-        t = self.text
-
-        if not self.playback_list or e.canceled:
-            self._post_playback()
-            return
-
-        if not e.executing:# or e.reading:
-            line, enter = self.playback_list.pop(0)
-            t.mark_gravity('iomark', 'left')
-            t.insert('insert', line)
-            if e.color:
-                e.color.recolorize()
-            if enter:
-                t.event_generate('<Return>')
-                t.see('insert')
-
-        t.after(10, self.do_playback)
-
-
+    def find_max_indent(self, lines):
+        """
+        Return the common indentation shared by all lines,
+        not including empty and comment lines
+        """
+        Lcode = [line for line in lines
+                 if line.rstrip() and not line.lstrip().startswith('#')]
+        indentation = []
+        idx = 0
+        while True:
+            cur_char = set(line[idx] for line in Lcode)
+            if len(cur_char) != 1: break
+            indent_char = list(cur_char)[0]
+            if indent_char not in INDENT_CHARS: break
+            indentation.append(indent_char)
+            idx += 1
+        return "".join(indentation)

--- a/idlesporklib/MultiLineRun.py
+++ b/idlesporklib/MultiLineRun.py
@@ -37,18 +37,16 @@ class MultiLineDelegator(Delegator):
         self.paste = False
 
     def insert(self, index, chars, tags=None):
-        do_insert = True
         if self.paste:
             self.paste = False
             try:
-                do_insert = self.callback(chars)
+                chars = self.callback(chars)
             except Exception as err:
                 # Must catch exception else IDLE closes
                 print(' MultiLineRun Internal Error', file=sys.stderr)
                 traceback.print_exc()
 
-        if do_insert:
-            self.delegate.insert(index, chars, tags)
+        self.delegate.insert(index, chars, tags)
 
     def delete(self, index1, index2=None):
         self.delegate.delete(index1, index2)
@@ -76,19 +74,16 @@ class MultiLineRun(object):
         self.mld.paste = True
 
     def paste_intercept(self, chars):
-        self.mld.paste = False
         if self.editwin.executing:
-            return True
+            # Do nothing
+            return chars
 
-        self.play(chars)
-
-    def play(self, chars):
         chars = self.eol_re.sub(r"\n", chars)
 
         lines = chars.splitlines()
         lines = self.dedent(lines)
 
-        self.text.insert("insert", "\n".join(lines))
+        return "\n".join(lines)
 
     def dedent(self, lines):
         """

--- a/idlesporklib/MultiLineRun.py
+++ b/idlesporklib/MultiLineRun.py
@@ -1,0 +1,172 @@
+# IDLEX EXTENSION
+##    """
+##    Copyright(C) 2012 The Board of Trustees of the University of Illinois.
+##    All rights reserved.
+##    Developed by:   Roger D. Serwy
+##                    University of Illinois
+##    License: See LICENSE.txt
+##    """
+
+
+
+##
+##  This extension allows for pasting of multiple lines of code into the shell
+##  for execution. This addresses http://bugs.python.org/issue3559
+##  Ofir: I fixed the function "dedent", still needs work.
+
+from __future__ import print_function
+
+config_extension_def = """
+[MultiLineRun]
+enable=1
+enable_editor=0
+enable_shell=1
+"""
+
+from idlesporklib.configHandler import idleConf
+from idlesporklib.Delegator import Delegator
+import time
+import re
+import sys
+import traceback
+
+class MultiLineDelegator(Delegator):
+    def __init__(self, callback):
+        Delegator.__init__(self)
+        self.callback = callback
+        self.paste = False
+
+    def insert(self, index, chars, tags=None):
+        do_insert = True
+        if self.paste:
+            self.paste = False
+            try:
+                do_insert = self.callback(chars)
+            except Exception as err:
+                # Must catch exception else IDLE closes
+                print(' MultiLineRun Internal Error', file=sys.stderr)
+                traceback.print_exc()
+
+        if do_insert:
+            self.delegate.insert(index, chars, tags)
+
+    def delete(self, index1, index2=None):
+        self.delegate.delete(index1, index2)
+
+
+class MultiLineRun:
+
+    # eol code from IOBinding.py
+    eol = r"(\r\n)|\n|\r"  # \r\n (Windows), \n (UNIX), or \r (Mac)
+    eol_re = re.compile(eol)
+
+    def __init__(self, editwin):
+        self.editwin = editwin      # reference to the editor window
+        self.text = text = self.editwin.text
+
+        self.mld = MultiLineDelegator(self.paste_intercept)
+        self.editwin.per.insertfilter(self.mld)
+
+        self.text.bind('<<Paste>>', self.paste, '+')
+
+        wsys = text.tk.call('tk', 'windowingsystem')
+        if wsys == 'x11':
+            self.text.bind('<Button-2>', self.paste, '+')  # For X11 middle click
+
+        self.playback_list = []
+
+    def paste(self, event=None):
+        self.mld.paste = True
+
+    def paste_intercept(self, chars):
+        self.mld.paste = False
+        if self.editwin.executing:
+            return True
+
+        self.play(chars)
+
+    def play(self, chars):
+        chars = self.eol_re.sub(r"\n", chars)
+
+        L = [] # list of entries to play into the shell
+        index = 0
+        while True:
+            next_index = chars.find('\n', index)
+            if next_index > -1:
+                line = chars[index:next_index]
+                L.append((line, True))
+            else:
+                line = chars[index:]
+                L.append((line, False))
+                break
+            index = next_index + 1
+
+        L = self.dedent(L)
+        self.playback_list = L
+        self._pre_playback()
+        self.do_playback()
+
+    def dedent(self, L):
+        """
+        remove maximal amount of indents/spaces shared by all lines
+        to enable pasting an equally indented region
+        Also remove empty lines, because they cause execution half-way
+        """
+        # exclude commented-out lines, empty lines for calculation of greatest common indent to strip
+        Lcode = [line for line,ret in L if line.rstrip() and not line.startswith('#')]
+
+        # calculate min number of tabs
+        dedent_tab =0
+        while all(map(lambda line: line.startswith('\t'),Lcode)):
+            Lcode = [x[1:] for x in Lcode]
+            dedent_tab += 1
+
+        if not dedent_tab:
+            dedent_space = 0
+            while all(map(lambda line: line.startswith(' '), Lcode)):
+                Lcode = [x[1:] for x in Lcode]
+                dedent_space += 1
+            depth = dedent_space
+            src = '\n'.join([line for line,ret in L if line.rstrip()])
+            src = re.sub(r"(?<![^\n]) {%i,%i}" % (depth, depth), "", src)
+            L = zip(src.split('\n'),[ret for line,ret in L if line.rstrip()])
+        else:
+            depth = dedent_tab
+            src = '\n'.join([line for line,ret in L if line.rstrip()])
+            src = re.sub(r"(?<![^\n])\t{%i,%i}" % (depth, depth), "", src)
+            L = zip(src.split('\n'),[ret for line,ret in L if line.rstrip()])
+
+        return L
+
+    def _pre_playback(self):
+        # newline_and_indent can be problematic - replace it momentarily
+        self.n = self.editwin.newline_and_indent_event
+        def simple_return(text = self.text):
+            text.insert('insert', '\n')
+        self.editwin.newline_and_indent_event = lambda *args, **kwargs: simple_return()
+
+    def _post_playback(self):
+        self.editwin.newline_and_indent_event = self.n
+
+    def do_playback(self):
+        self.mld.paste = False
+        e = self.editwin
+        t = self.text
+
+        if not self.playback_list or e.canceled:
+            self._post_playback()
+            return
+
+        if not e.executing:# or e.reading:
+            line, enter = self.playback_list.pop(0)
+            t.mark_gravity('iomark', 'left')
+            t.insert('insert', line)
+            if e.color:
+                e.color.recolorize()
+            if enter:
+                t.event_generate('<Return>')
+                t.see('insert')
+
+        t.after(10, self.do_playback)
+
+

--- a/idlesporklib/config-extensions.def
+++ b/idlesporklib/config-extensions.def
@@ -102,6 +102,11 @@ zoom-height=<Alt-Key-2>
 [BetterOutput]
 enable=1
 
+[MultiLineRun]
+enable=1
+enable_editor=0
+enable_shell=1
+
 [Squeezer]
 enable=1
 max-num-of-lines=30

--- a/idlesporklib/licenses/idlex_LICENSE.txt
+++ b/idlesporklib/licenses/idlex_LICENSE.txt
@@ -1,0 +1,32 @@
+Copyright(C) 2011-2012 The Board of Trustees of the University of Illinois.  
+All rights reserved.
+
+Developed by:   Roger D. Serwy
+                University of Illinois
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal with the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
++ Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimers.
++ Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimers in the
+  documentation and/or other materials provided with the distribution.
++ Neither the names of Roger D. Serwy, the University of Illinois, nor
+  the names of its contributors may be used to endorse or promote
+  products derived from this Software without specific prior written
+  permission. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
+


### PR DESCRIPTION
Largely copied from [idlex](http://idlex.sourceforge.net/extensions.html). Changed idlelib to idlesporklib and fixed the function dedent to eliminate tabs and spaces common to all lines to facilitate running indented code. Also removes blank lines so indented code isn't run half-way, causing erros.
Also changed config-extensions.def to activate the package.

Ideally we would want all pasted code to not be run automatically (or line by line) but to be pasted as if somebody typed it with alt+enter after every line, so it's one block of code. But I don't know how to do that.
