### PR TITLE
AutoComplete on arguments, better CallTips, run multiple lines in shell, and see cpu and mem usage!

### DIFF
--- a/idlesporklib/AutoComplete.py
+++ b/idlesporklib/AutoComplete.py
@@ -138,14 +138,11 @@ class AutoComplete:
         if hp.is_in_dict() and (not mode or mode==COMPLETE_KEYS) and evalfuncs:
             self._remove_autocomplete_window()
             mode = COMPLETE_KEYS
-            while i and curline[i - 1] in ID_CHARS:
+            while i and curline[i - 1] in ID_CHARS + '"' + "'":
                 i -= 1
             comp_start = curline[i:j]
-            if curline[i - 2:i] == "['":
-                hp.set_index("insert-%dc" % (len(curline) - (i - 2)))
-                comp_what = hp.get_expression()
-            elif curline[i - 3:i] == "[u'":
-                hp.set_index("insert-%dc" % (len(curline) - (i - 3)))
+            if curline[i - 1:i] == "[":
+                hp.set_index("insert-%dc" % (len(curline) - (i - 1)))
                 comp_what = hp.get_expression()
             else:
                 comp_what = ""
@@ -253,13 +250,26 @@ class AutoComplete:
             elif mode == COMPLETE_KEYS:
                     try:
                         entity = self.get_entity(what)
-                        smalll = bigl = sorted(entity.keys())
+                        smalll = bigl = sorted(set(map(self.key_repr, entity.keys())))
+                        if smalll[0] is None:
+                            del smalll[0]
                     except:
                         return [], []
 
             if not smalll:
                 smalll = bigl
             return smalll, bigl
+
+    @staticmethod
+    def key_repr(key):
+        try:
+            r = repr(key)
+            if r.startswith('<'):
+                return None
+            else:
+                return r
+        except:
+            return None
 
     def get_entity(self, name):
         """Lookup name in a namespace spanning sys.modules and __main.dict__"""

--- a/idlesporklib/AutoComplete.py
+++ b/idlesporklib/AutoComplete.py
@@ -168,6 +168,15 @@ class AutoComplete:
         comp_lists = self.fetch_completions(comp_what, mode)
         if not comp_lists[0]:
             return
+
+        if mode == COMPLETE_ATTRIBUTES:
+            calltips = self.editwin.extensions.get('CallTips')
+            if calltips:
+                args = calltips.arg_names(evalfuncs)
+                if args:
+                    args = [a + '=' for a in args]
+                    comp_lists = sorted(comp_lists[0] + args), sorted(comp_lists[1] + args)
+
         self.autocompletewindow = self._make_autocomplete_window()
         return not self.autocompletewindow.show_window(
                 comp_lists, "insert-%dc" % len(comp_start),

--- a/idlesporklib/AutoComplete.py
+++ b/idlesporklib/AutoComplete.py
@@ -243,33 +243,32 @@ class AutoComplete:
                     from os.path import normcase
                     expandedpath = os.path.expanduser(what)
                     bigl = os.listdir(expandedpath)
-                    bigl = sorted(set(bigl), cmp=lambda x,y: cmp(normcase(x), normcase(y)))
+                    try:
+                        cmp_ = cmp
+                    except NameError:
+                        cmp_ = lambda x, y: (x > y) - (x < y)
+                    bigl = sorted(set(bigl), cmp=lambda x,y: cmp_(normcase(x), normcase(y)))
                     smalll = [s for s in bigl if s[:1] != '.']
                 except OSError:
                     return [], []
             elif mode == COMPLETE_KEYS:
                     try:
                         entity = self.get_entity(what)
-                        smalll = bigl = sorted(set(map(self.key_repr, entity.keys())))
-                        if smalll[0] is None:
-                            del smalll[0]
+                        keys = set()
+                        for key in entity.keys():
+                            try:
+                                r = repr(key)
+                                if not r.startswith('<'):
+                                    keys.add(r)
+                            except:
+                                pass
+                        smalll = bigl = sorted(keys)
                     except:
                         return [], []
 
             if not smalll:
                 smalll = bigl
             return smalll, bigl
-
-    @staticmethod
-    def key_repr(key):
-        try:
-            r = repr(key)
-            if r.startswith('<'):
-                return None
-            else:
-                return r
-        except:
-            return None
 
     def get_entity(self, name):
         """Lookup name in a namespace spanning sys.modules and __main.dict__"""

--- a/idlesporklib/CallTips.py
+++ b/idlesporklib/CallTips.py
@@ -211,6 +211,7 @@ def get_arg_names(ob):
     try:
         argcount = fob.func_code.co_argcount
         ret = list(fob.func_code.co_varnames[arg_offset:argcount])
+        ret = [arg for arg in ret if re.match("(?<!\d)\.\d+", arg) is None]
         return ret
     except:
         return

--- a/idlesporklib/CallTips.py
+++ b/idlesporklib/CallTips.py
@@ -232,7 +232,7 @@ def get_arg_text(ob):
     # Try to build one for Python defined functions
     if type(fob) in [types.FunctionType, types.LambdaType]:
         argcount = fob.func_code.co_argcount
-        real_args = fob.func_code.co_varnames[arg_offset:argcount]
+        real_args = list(fob.func_code.co_varnames[arg_offset:argcount])
         defaults = fob.func_defaults or []
         defaults = list(map(lambda name: "=%s" % repr(name), defaults))
         defaults = [""] * (len(real_args) - len(defaults)) + defaults

--- a/idlesporklib/HyperParser.py
+++ b/idlesporklib/HyperParser.py
@@ -113,14 +113,11 @@ class HyperParser:
 
     def is_in_dict(self):
         """Is the index given to the HyperParser in a dict getitem?"""
-        if not self.isopener[self.indexbracket]:
-            return True
-        ind = self.bracketing[self.indexbracket][0]
-        if self.rawtext[ind] == '#' or \
-                (self.rawtext[ind] in ['"', "'"] and
-                 not (self.rawtext[ind - 1:ind] == '[' or self.rawtext[ind - 2:ind] == '[u')):
-            return False
-        return True
+        return (self.isopener[self.indexbracket] and
+                ((self.bracketing[self.indexbracket][0] and self.rawtext[self.bracketing[self.indexbracket][0]]
+                in ('"', "'") and self.rawtext[self.bracketing[self.indexbracket][0] - 1] == '[') or
+                 (self.rawtext[self.bracketing[self.indexbracket][0]]  == '[')
+                 ))
 
     def get_surrounding_brackets(self, openers='([{', mustclose=False):
         """Return bracket indexes or None.

--- a/idlesporklib/HyperParser.py
+++ b/idlesporklib/HyperParser.py
@@ -111,6 +111,17 @@ class HyperParser:
                 self.rawtext[self.bracketing[self.indexbracket][0]]
                 not in ('#', '"', "'"))
 
+    def is_in_dict(self):
+        """Is the index given to the HyperParser in a dict getitem?"""
+        if not self.isopener[self.indexbracket]:
+            return True
+        ind = self.bracketing[self.indexbracket][0]
+        if self.rawtext[ind] == '#' or \
+                (self.rawtext[ind] in ['"', "'"] and
+                 not (self.rawtext[ind - 1:ind] == '[' or self.rawtext[ind - 2:ind] == '[u')):
+            return False
+        return True
+
     def get_surrounding_brackets(self, openers='([{', mustclose=False):
         """Return bracket indexes or None.
 
@@ -176,7 +187,7 @@ class HyperParser:
         """Return a string with the Python expression which ends at the
         given index, which is empty if there is no real one.
         """
-        if not self.is_in_code():
+        if not self.is_in_code() and not self.is_in_dict():
             raise ValueError("get_expression should only be called"
                              "if index is inside a code.")
 

--- a/idlesporklib/ResourcesStatus.py
+++ b/idlesporklib/ResourcesStatus.py
@@ -14,9 +14,13 @@ class ResourcesStatus(object):
         if psutil is not None:
             self.editwin = editwin
             self.text = self.editwin.text
-            self.editwin.status_bar.set_label('cpu', 'Cpu: ?', side=RIGHT)
-            self.editwin.status_bar.set_label('mem', 'Mem: ?', side=RIGHT)
-            self.text.after_idle(self.set_cpu_and_mem)
+            try:
+                interp = self.editwin.interp
+                self.editwin.status_bar.set_label('cpu', 'Cpu: ?', side=RIGHT)
+                self.editwin.status_bar.set_label('mem', 'Mem: ?', side=RIGHT)
+                self.text.after_idle(self.set_cpu_and_mem)
+            except AttributeError:
+                pass
         else:
             print("ResourcesStatus extension could not find the psutil module.")
 

--- a/idlesporklib/ResourcesStatus.py
+++ b/idlesporklib/ResourcesStatus.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python
+from __future__ import print_function
+
+from Tkinter import RIGHT
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+
+class ResourcesStatus(object):
+    def __init__(self, editwin):
+        if psutil is not None:
+            self.editwin = editwin
+            self.text = self.editwin.text
+            self.editwin.status_bar.set_label('cpu', 'Cpu: ?', side=RIGHT)
+            self.editwin.status_bar.set_label('mem', 'Mem: ?', side=RIGHT)
+            self.text.after_idle(self.set_cpu_and_mem)
+        else:
+            print("ResourcesStatus extension could not find the psutil module.")
+
+    def set_cpu_and_mem(self, event=None):
+        process = psutil.Process(self.editwin.interp.rpcpid)
+        cpu = process.cpu_percent(0.1)
+        mem = process.memory_percent()
+        self.editwin.status_bar.set_label('cpu', 'Cpu: %.1f' % cpu)
+        self.editwin.status_bar.set_label('mem', 'Mem: %.1f' % mem)
+        self.text.after(1000, self.set_cpu_and_mem)

--- a/idlesporklib/config-extensions.def
+++ b/idlesporklib/config-extensions.def
@@ -35,6 +35,7 @@
 [AutoComplete]
 enable=True
 popupwait=2000
+onlycontaining=False
 [AutoComplete_cfgBindings]
 force-open-completions=<Control-Key-space>
 [AutoComplete_bindings]

--- a/idlesporklib/config-extensions.def
+++ b/idlesporklib/config-extensions.def
@@ -54,6 +54,9 @@ force-open-calltip=<Control-Key-backslash>
 try-open-calltip=<KeyRelease-parenleft>
 refresh-calltip=<KeyRelease-parenright> <KeyRelease-0>
 
+[ResourcesStatus]
+enable=True
+
 [CodeContext]
 enable=True
 enable_shell=False

--- a/idlesporklib/config-extensions.def
+++ b/idlesporklib/config-extensions.def
@@ -55,7 +55,7 @@ try-open-calltip=<KeyRelease-parenleft>
 refresh-calltip=<KeyRelease-parenright> <KeyRelease-0>
 
 [ResourcesStatus]
-enable=True
+enable=False
 
 [CodeContext]
 enable=True

--- a/idlesporklib/config-extensions.def
+++ b/idlesporklib/config-extensions.def
@@ -35,6 +35,7 @@
 [AutoComplete]
 enable=True
 popupwait=2000
+imports=False
 onlycontaining=False
 [AutoComplete_cfgBindings]
 force-open-completions=<Control-Key-space>


### PR DESCRIPTION
Hello!

I managed to make a pull request!! :)
But not more than one...

CallTips: I refactored a bit so it would be easier to implement the above functionality. Also, if the function has a tuple in its def or unpacking arguments, the correct names are now showed. For the former there is a new delist function, and for the latter it's a simple change in the loop. ALSO: the calltip now breaks long function defs into lines!!! YES!!!!

AutoComplete changes: if CallTips extension is enabled, it can be used to get argument names while typing a function call.

MultiLineRun: added right click menu to run a few selected lines. You select a few lines, right click, choose run lines, and they run.

ResourcesStatus: working on some big data I realised my ram keeps running out, and also I wanted to make sure that some parallel functions actually run in parallel (in external C libraries), so I added this.

Hope someone finds these useful.

Dror